### PR TITLE
2.Dissecting QML Syntax updated

### DIFF
--- a/2.DissectingQmlSyntax/1-SyntaxOverview/CMakeLists.txt
+++ b/2.DissectingQmlSyntax/1-SyntaxOverview/CMakeLists.txt
@@ -5,23 +5,28 @@ cmake_minimum_required(VERSION 3.16)
 
 project(1-SyntaxOverview VERSION 0.1 LANGUAGES CXX)
 
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Quick)
+find_package(Qt6 REQUIRED COMPONENTS Quick)
 
-qt_standard_project_setup(REQUIRES 6.5)
+set(MY_TARGET app1-SyntaxOverview)
 
-qt_add_executable(app1-SyntaxOverview
+qt_standard_project_setup()
+
+qt_add_executable(${MY_TARGET}
     main.cpp
 )
 
-qt_add_qml_module(app1-SyntaxOverview
+qt_add_qml_module(${MY_TARGET}
     URI 1-SyntaxOverview
     VERSION 1.0
     QML_FILES Main.qml
 )
 
-set_target_properties(app1-SyntaxOverview PROPERTIES
+set_target_properties(${MY_TARGET} PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
@@ -29,12 +34,20 @@ set_target_properties(app1-SyntaxOverview PROPERTIES
     WIN32_EXECUTABLE TRUE
 )
 
-target_link_libraries(app1-SyntaxOverview
+target_link_libraries(${MY_TARGET}
     PRIVATE Qt6::Quick
 )
 
-install(TARGETS app1-SyntaxOverview
+install(TARGETS ${MY_TARGET}
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+qt_generate_deploy_app_script(
+    TARGET ${MY_TARGET}
+    OUTPUT_SCRIPT deploy_script
+    NO_UNSUPPORTED_PLATFORM_ERROR
+)
+
+install(SCRIPT ${deploy_script})

--- a/2.DissectingQmlSyntax/1-SyntaxOverview/Main.qml
+++ b/2.DissectingQmlSyntax/1-SyntaxOverview/Main.qml
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import QtQuick
+import QtQuick.Controls
 
 Window {
     id: rootId
@@ -12,53 +13,62 @@ Window {
 
     property string textToShow: "hello"
 
+    function handleRectangleClick(text){
+        console.log("Clicked on the " + text + " rectangle");
+        textToShow = text;
+    }
+
     Row {
         id: row1
         anchors.centerIn: parent
         spacing: 20
 
-        Rectangle {
-            id: redRectId
-            width: 100; height: 100
-            color: "red"
-            radius: 20
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    console.log("Clicked on the red rectangle")
-                    textToShow = "red"
-                }
-            }
-        }
+        // Rectangle {
+        //     id: redRectId
+        //     width: 100; height: 100
+        //     color: "red"
+        //     radius: 20
+        //     MouseArea {
+        //         anchors.fill: parent
+        //         onClicked: handleRectangleClick("red")
+        //     }
+        // }
 
-        Rectangle {
-            id: greenRectId
-            width: 100; height: 100
-            color: "green"
-            radius: 20
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    console.log("Clicked on the green rectangle")
-                    textToShow = "green"
-                }
-            }
-        }
+        // Rectangle {
+        //     id: greenRectId
+        //     width: 100; height: 100
+        //     color: "green"
+        //     radius: 20
+        //     MouseArea {
+        //         anchors.fill: parent
+        //         onClicked: handleRectangleClick("green")
+        //     }
+        // }
 
-        Rectangle {
-            id: blueRectId
-            width: 100; height: 100
-            color: "blue"
-            radius: 20
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    console.log("Clicked on the blue rectangle")
-                    textToShow = "blue"
-                }
-            }
-        }
+        // Rectangle {
+        //     id: blueRectId
+        //     width: 100; height: 100
+        //     color: "blue"
+        //     radius: 20
+        //     MouseArea {
+        //         anchors.fill: parent
+        //         onClicked: handleRectangleClick("blue")
+        //     }
+        // }
 
+        Repeater {
+                   model: ["red", "green", "blue"]
+
+                   Rectangle {
+                       width: 100; height: 100
+                       color: modelData
+                       radius: 20
+                       MouseArea {
+                           anchors.fill: parent
+                           onClicked: handleRectangleClick(modelData)
+                       }
+                   }
+           }
         Rectangle {
             id: textRectId
             width: 100; height: 100

--- a/2.DissectingQmlSyntax/2-ExploringDataTypes/.clang-format
+++ b/2.DissectingQmlSyntax/2-ExploringDataTypes/.clang-format
@@ -1,0 +1,97 @@
+AccessModifierOffset: -2
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: true
+  SplitEmptyRecord: true
+BreakAfterJavaFieldAnnotations: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializersBeforeComma: false
+BreakStringLiterals: true
+ColumnLimit: 120
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: true
+FixNamespaceComments: true
+ForEachMacros:
+- foreach
+- Q_FOREACH
+- BOOST_FOREACH
+IncludeCategories:
+- Priority: 2
+  Regex: ^"(llvm|llvm-c|clang|clang-c)/
+- Priority: 3
+  Regex: ^(<|"(gtest|gmock|isl|json)/)
+- Priority: 1
+  Regex: .*
+IncludeIsMainRegex: (Test)?$
+IndentCaseLabels: false
+IndentWidth: 2
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+ObjCBlockIndentWidth: 7
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++17
+TabWidth: 8
+UseTab: Never

--- a/2.DissectingQmlSyntax/2-ExploringDataTypes/CMakeLists.txt
+++ b/2.DissectingQmlSyntax/2-ExploringDataTypes/CMakeLists.txt
@@ -5,23 +5,29 @@ cmake_minimum_required(VERSION 3.16)
 
 project(2-ExploringDataTypes VERSION 0.1 LANGUAGES CXX)
 
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Quick)
+find_package(Qt6 REQUIRED COMPONENTS Quick)
 
-qt_standard_project_setup(REQUIRES 6.5)
+set(MY_TARGET app2-ExploringDataTypes)
 
-qt_add_executable(app2-ExploringDataTypes
+qt_standard_project_setup()
+
+qt_add_executable(${MY_TARGET}
     main.cpp
 )
 
-qt_add_qml_module(app2-ExploringDataTypes
+qt_add_qml_module(${MY_TARGET}
     URI 2-ExploringDataTypes
     VERSION 1.0
     QML_FILES Main.qml
 )
 
-set_target_properties(app2-ExploringDataTypes PROPERTIES
+set_target_properties(${MY_TARGET} PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
@@ -29,12 +35,20 @@ set_target_properties(app2-ExploringDataTypes PROPERTIES
     WIN32_EXECUTABLE TRUE
 )
 
-target_link_libraries(app2-ExploringDataTypes
+target_link_libraries(${MY_TARGET}
     PRIVATE Qt6::Quick
 )
 
-install(TARGETS app2-ExploringDataTypes
+install(TARGETS ${MY_TARGET}
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+qt_generate_deploy_app_script(
+    TARGET ${MY_TARGET}
+    OUTPUT_SCRIPT deploy_script
+    NO_UNSUPPORTED_PLATFORM_ERROR
+)
+
+install(SCRIPT ${deploy_script})

--- a/2.DissectingQmlSyntax/2-ExploringDataTypes/Main.qml
+++ b/2.DissectingQmlSyntax/2-ExploringDataTypes/Main.qml
@@ -15,9 +15,9 @@ Window {
     property double mDouble: 77.5
     property url mUrl: "https://www.learnqt.guide"
 
-    property var aNumber: 100
-    property var aBool: false
-    property var aString: "Hello world!"
+    property var aNumber: 100 // not-recommended (use int or real to better performance)
+    property var aBool: false // same-case
+    property var aString: "Hello world!" // similar  case
     property var anotherString: String("#FF008800")
     property var aColor: Qt.rgba(0.2, 0.3, 0.4, 0.5)
     property var aRect: Qt.rect(10, 10, 10, 10)

--- a/2.DissectingQmlSyntax/2-ExploringDataTypes/main.cpp
+++ b/2.DissectingQmlSyntax/2-ExploringDataTypes/main.cpp
@@ -6,14 +6,17 @@
 
 int main(int argc, char *argv[])
 {
-	
-	QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine;
-    QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
-        &app, []() { QCoreApplication::exit(-1); },
-        Qt::QueuedConnection);
-    engine.loadFromModule("2-ExploringDataTypes", "Main");
+  QGuiApplication app(argc, argv);
 
-    return app.exec();
+  QQmlApplicationEngine engine;
+  QObject::connect(
+    &engine,
+    &QQmlApplicationEngine::objectCreationFailed,
+    &app,
+    []() { QCoreApplication::exit(-1); },
+    Qt::QueuedConnection);
+  engine.loadFromModule("2-ExploringDataTypes", "Main");
+
+  return app.exec();
 }

--- a/2.DissectingQmlSyntax/3-PropertyBinding/.clang-format
+++ b/2.DissectingQmlSyntax/3-PropertyBinding/.clang-format
@@ -1,0 +1,97 @@
+AccessModifierOffset: -2
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: true
+  SplitEmptyRecord: true
+BreakAfterJavaFieldAnnotations: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializersBeforeComma: false
+BreakStringLiterals: true
+ColumnLimit: 120
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: true
+FixNamespaceComments: true
+ForEachMacros:
+- foreach
+- Q_FOREACH
+- BOOST_FOREACH
+IncludeCategories:
+- Priority: 2
+  Regex: ^"(llvm|llvm-c|clang|clang-c)/
+- Priority: 3
+  Regex: ^(<|"(gtest|gmock|isl|json)/)
+- Priority: 1
+  Regex: .*
+IncludeIsMainRegex: (Test)?$
+IndentCaseLabels: false
+IndentWidth: 2
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+ObjCBlockIndentWidth: 7
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++17
+TabWidth: 8
+UseTab: Never

--- a/2.DissectingQmlSyntax/3-PropertyBinding/CMakeLists.txt
+++ b/2.DissectingQmlSyntax/3-PropertyBinding/CMakeLists.txt
@@ -7,21 +7,23 @@ project(3-PropertyBinding VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Quick)
+find_package(Qt6 REQUIRED COMPONENTS Quick)
 
-qt_standard_project_setup(REQUIRES 6.5)
+set(MY_TARGET app3-PropertyBinding)
 
-qt_add_executable(app3-PropertyBinding
+qt_standard_project_setup()
+
+qt_add_executable(${MY_TARGET}
     main.cpp
 )
 
-qt_add_qml_module(app3-PropertyBinding
+qt_add_qml_module(${MY_TARGET}
     URI 3-PropertyBinding
     VERSION 1.0
     QML_FILES Main.qml
 )
 
-set_target_properties(app3-PropertyBinding PROPERTIES
+set_target_properties(${MY_TARGET} PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
@@ -29,12 +31,21 @@ set_target_properties(app3-PropertyBinding PROPERTIES
     WIN32_EXECUTABLE TRUE
 )
 
-target_link_libraries(app3-PropertyBinding
+target_link_libraries(${MY_TARGET}
     PRIVATE Qt6::Quick
 )
 
-install(TARGETS app3-PropertyBinding
+install(TARGETS ${MY_TARGET}
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+qt_generate_deploy_app_script(
+    TARGET ${MY_TARGET}
+    OUTPUT_SCRIPT deploy_script
+    NO_UNSUPPORTED_PLATFORM_ERROR
+)
+
+install(SCRIPT ${deploy_script})
+

--- a/2.DissectingQmlSyntax/3-PropertyBinding/main.cpp
+++ b/2.DissectingQmlSyntax/3-PropertyBinding/main.cpp
@@ -6,14 +6,17 @@
 
 int main(int argc, char *argv[])
 {
-	
-	QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine;
-    QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
-        &app, []() { QCoreApplication::exit(-1); },
-        Qt::QueuedConnection);
-    engine.loadFromModule("3-PropertyBinding", "Main");
+  QGuiApplication app(argc, argv);
 
-    return app.exec();	
+  QQmlApplicationEngine engine;
+  QObject::connect(
+    &engine,
+    &QQmlApplicationEngine::objectCreationFailed,
+    &app,
+    []() { QCoreApplication::exit(-1); },
+    Qt::QueuedConnection);
+  engine.loadFromModule("3-PropertyBinding", "Main");
+
+  return app.exec();
 }

--- a/2.DissectingQmlSyntax/4-QtGlobalObject/.clang-format
+++ b/2.DissectingQmlSyntax/4-QtGlobalObject/.clang-format
@@ -1,0 +1,97 @@
+AccessModifierOffset: -2
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: true
+  SplitEmptyRecord: true
+BreakAfterJavaFieldAnnotations: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializersBeforeComma: false
+BreakStringLiterals: true
+ColumnLimit: 120
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: true
+FixNamespaceComments: true
+ForEachMacros:
+- foreach
+- Q_FOREACH
+- BOOST_FOREACH
+IncludeCategories:
+- Priority: 2
+  Regex: ^"(llvm|llvm-c|clang|clang-c)/
+- Priority: 3
+  Regex: ^(<|"(gtest|gmock|isl|json)/)
+- Priority: 1
+  Regex: .*
+IncludeIsMainRegex: (Test)?$
+IndentCaseLabels: false
+IndentWidth: 2
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+ObjCBlockIndentWidth: 7
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++17
+TabWidth: 8
+UseTab: Never

--- a/2.DissectingQmlSyntax/4-QtGlobalObject/CMakeLists.txt
+++ b/2.DissectingQmlSyntax/4-QtGlobalObject/CMakeLists.txt
@@ -7,21 +7,22 @@ project(4-QtGlobalObject VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Quick)
+find_package(Qt6 REQUIRED COMPONENTS Quick)
 
-qt_standard_project_setup(REQUIRES 6.5)
+set(MY_TARGET app4-QtGlobalObject)
+qt_standard_project_setup()
 
-qt_add_executable(app4-QtGlobalObject
+qt_add_executable(${MY_TARGET}
     main.cpp
 )
 
-qt_add_qml_module(app4-QtGlobalObject
+qt_add_qml_module(${MY_TARGET}
     URI 4-QtGlobalObject
     VERSION 1.0
     QML_FILES Main.qml
 )
 
-set_target_properties(app4-QtGlobalObject PROPERTIES
+set_target_properties(${MY_TARGET} PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
@@ -29,12 +30,20 @@ set_target_properties(app4-QtGlobalObject PROPERTIES
     WIN32_EXECUTABLE TRUE
 )
 
-target_link_libraries(app4-QtGlobalObject
+target_link_libraries(${MY_TARGET}
     PRIVATE Qt6::Quick
 )
 
-install(TARGETS app4-QtGlobalObject
+install(TARGETS ${MY_TARGET}
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+qt_generate_deploy_app_script(
+    TARGET ${MY_TARGET}
+    OUTPUT_SCRIPT deploy_script
+    NO_UNSUPPORTED_PLATFORM_ERROR
+)
+
+install(SCRIPT ${deploy_script})

--- a/2.DissectingQmlSyntax/4-QtGlobalObject/Main.qml
+++ b/2.DissectingQmlSyntax/4-QtGlobalObject/Main.qml
@@ -9,7 +9,7 @@ Window {
     height: 480
     title: qsTr("Qt Global Object Demo")
 
-    property var fonts: Qt.fontFamilies()
+    readonly property var fonts: Qt.fontFamilies()
 
     Rectangle {
         width: 300

--- a/2.DissectingQmlSyntax/4-QtGlobalObject/main.cpp
+++ b/2.DissectingQmlSyntax/4-QtGlobalObject/main.cpp
@@ -6,14 +6,17 @@
 
 int main(int argc, char *argv[])
 {
-	
-	QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine;
-    QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
-        &app, []() { QCoreApplication::exit(-1); },
-        Qt::QueuedConnection);
-    engine.loadFromModule("4-QtGlobalObject", "Main");
+  QGuiApplication app(argc, argv);
 
-    return app.exec();
+  QQmlApplicationEngine engine;
+  QObject::connect(
+    &engine,
+    &QQmlApplicationEngine::objectCreationFailed,
+    &app,
+    []() { QCoreApplication::exit(-1); },
+    Qt::QueuedConnection);
+  engine.loadFromModule("4-QtGlobalObject", "Main");
+
+  return app.exec();
 }

--- a/2.DissectingQmlSyntax/5-PropertyHandlers/.clang-format
+++ b/2.DissectingQmlSyntax/5-PropertyHandlers/.clang-format
@@ -1,0 +1,97 @@
+AccessModifierOffset: -2
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: true
+  SplitEmptyRecord: true
+BreakAfterJavaFieldAnnotations: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializersBeforeComma: false
+BreakStringLiterals: true
+ColumnLimit: 120
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: true
+FixNamespaceComments: true
+ForEachMacros:
+- foreach
+- Q_FOREACH
+- BOOST_FOREACH
+IncludeCategories:
+- Priority: 2
+  Regex: ^"(llvm|llvm-c|clang|clang-c)/
+- Priority: 3
+  Regex: ^(<|"(gtest|gmock|isl|json)/)
+- Priority: 1
+  Regex: .*
+IncludeIsMainRegex: (Test)?$
+IndentCaseLabels: false
+IndentWidth: 2
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+ObjCBlockIndentWidth: 7
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++17
+TabWidth: 8
+UseTab: Never

--- a/2.DissectingQmlSyntax/5-PropertyHandlers/CMakeLists.txt
+++ b/2.DissectingQmlSyntax/5-PropertyHandlers/CMakeLists.txt
@@ -7,21 +7,23 @@ project(5-PropertyHandlers VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Quick)
+find_package(Qt6 REQUIRED COMPONENTS Quick)
 
-qt_standard_project_setup(REQUIRES 6.5)
+set(MY_TARGET app5-PropertyHandlers)
 
-qt_add_executable(app5-PropertyHandlers
+qt_standard_project_setup()
+
+qt_add_executable(${MY_TARGET}
     main.cpp
 )
 
-qt_add_qml_module(app5-PropertyHandlers
+qt_add_qml_module(${MY_TARGET}
     URI 5-PropertyHandlers
     VERSION 1.0
     QML_FILES Main.qml
 )
 
-set_target_properties(app5-PropertyHandlers PROPERTIES
+set_target_properties(${MY_TARGET} PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
@@ -29,11 +31,11 @@ set_target_properties(app5-PropertyHandlers PROPERTIES
     WIN32_EXECUTABLE TRUE
 )
 
-target_link_libraries(app5-PropertyHandlers
+target_link_libraries(${MY_TARGET}
     PRIVATE Qt6::Quick
 )
 
-install(TARGETS app5-PropertyHandlers
+install(TARGETS ${MY_TARGET}
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/2.DissectingQmlSyntax/5-PropertyHandlers/Main.qml
+++ b/2.DissectingQmlSyntax/5-PropertyHandlers/Main.qml
@@ -11,10 +11,12 @@ Window {
     title: qsTr("Properties and Handlers Demo")
 
     property string firstName: "Daniel"
-    onFirstNameChanged: {
+    onFirstNameChanged: {// Note: naming convetion matter
         console.log("The firstname changed to: " + firstName)
     }
-
+    // onFirstNameDChanged: {// This will throw an error since with object do not have a property firstNamed
+    //     console.log("The firstname changed to: " + firstName)
+    // }
     onTitleChanged: {
         console.log("The new title is: " + rootId.title)
     }

--- a/2.DissectingQmlSyntax/5-PropertyHandlers/main.cpp
+++ b/2.DissectingQmlSyntax/5-PropertyHandlers/main.cpp
@@ -7,15 +7,17 @@
 
 int main(int argc, char *argv[])
 {
-	
-	QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine;
-    QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
-        &app, []() { QCoreApplication::exit(-1); },
-        Qt::QueuedConnection);
-    engine.loadFromModule("5-PropertyHandlers", "Main");
+  QGuiApplication app(argc, argv);
 
-    return app.exec();
+  QQmlApplicationEngine engine;
+  QObject::connect(
+    &engine,
+    &QQmlApplicationEngine::objectCreationFailed,
+    &app,
+    []() { QCoreApplication::exit(-1); },
+    Qt::QueuedConnection);
+  engine.loadFromModule("5-PropertyHandlers", "Main");
 
+  return app.exec();
 }


### PR DESCRIPTION
This PR does the following: 
- Makes the CMake script of each sub-lecture  versionless of Qt6
- Adds comments to the QML  files to the sub-lectures of Lecture 2.DissectingQMLSyntax.
- Formats the sources files in each sub-lecture using attached clang-file